### PR TITLE
Arreglar claims del token jwt y modificar sql

### DIFF
--- a/backend/scr/DigitalArs/Controllers/AuthController.cs
+++ b/backend/scr/DigitalArs/Controllers/AuthController.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Authorization;
 using DigitalArs.Data;
 using DigitalArs.Dtos;
 using DigitalArs.Services;
-using DigitalArs.Models;
+using System.Security.Claims;
 
 namespace DigitalArs.Controllers;
 
@@ -44,7 +44,8 @@ public class AuthController : ControllerBase
     [HttpGet("datos-usuario")]
     public async Task<IActionResult> GetDatosUsuario()
     {
-        var idUsuario = int.Parse(User.FindFirst("sub")?.Value!);
+        var sub = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var idUsuario = int.Parse(sub!);
         var usuario = await _context.USUARIO.FindAsync(idUsuario);
 
         if (usuario == null)

--- a/backend/scr/DigitalArs/Services/JwtService.cs
+++ b/backend/scr/DigitalArs/Services/JwtService.cs
@@ -1,8 +1,8 @@
 using Microsoft.IdentityModel.Tokens;
 using System.IdentityModel.Tokens.Jwt;
-using System.Security.Claims;
 using System.Text;
 using DigitalArs.Models;
+using System.Security.Claims;
 
 namespace DigitalArs.Services;
 
@@ -22,9 +22,9 @@ namespace DigitalArs.Services;
 
         var claims = new[]
         {
-            new Claim(JwtRegisteredClaimNames.Sub, user.ID_USUARIO.ToString()),
-            new Claim(JwtRegisteredClaimNames.Email, user.EMAIL),            
-            new Claim("role", user.ID_ROL.ToString())
+            new Claim(ClaimTypes.NameIdentifier, user.ID_USUARIO.ToString()),
+            new Claim(ClaimTypes.Email, user.EMAIL),            
+            new Claim(ClaimTypes.Role, user.ID_ROL.ToString())
         };
 
         var token = new JwtSecurityToken(

--- a/backend/scr/DigitalArs/appsettings.json
+++ b/backend/scr/DigitalArs/appsettings.json
@@ -12,8 +12,8 @@
 
   "Jwt": {
   "Key": "1234567890",
-  "Issuer": "DigitalArs",
-  "Audience": "DigitalArsUser",
-  "ExpireMinutes": 10
-}
+    "Issuer": "DigitalArs",
+    "Audience": "DigitalArsUser",
+    "ExpireMinutes": 10
+  }
 }

--- a/sql/DIGITALARS_DB.sql
+++ b/sql/DIGITALARS_DB.sql
@@ -83,248 +83,279 @@ INSERT INTO ROL(NOMBRE_ROL)
 VALUES('NORMAL');
 
 -- Admin
+-- Contraseña: 12341234
 INSERT INTO USUARIO (NOMBRE, EMAIL, PASS, ID_ROL)
-VALUES ('admin1', 'admin1@gmail.com', '12341234', 1);
+VALUES ('admin1', 'admin1@gmail.com', 'AQAAAAIAAYagAAAAEM6fUMzmUoPJX6f45bMFWCrNOUOKoyvZOdvWbOcroxiViiHuKyQ9ld423g45qZnuwg==', 1);
 DECLARE @ID_USUARIO INT = SCOPE_IDENTITY();
 INSERT INTO CUENTA (ID_USUARIO, SALDO, ALIAS, CBU)
 VALUES (@ID_USUARIO, 10000.00, 'digitalars.admin.1', 1234567890123456);
 GO
 
 -- Usuario 1
+-- Contraseña: clave123
 INSERT INTO USUARIO (NOMBRE, EMAIL, PASS, ID_ROL)
-VALUES ('Juan P rez', 'juan.perez@mail.com', 'clave123', 2);
+VALUES ('Juan P rez', 'juan.perez@mail.com', 'AQAAAAIAAYagAAAAEMwerU9rI6704Hpt7Xmz+lZsTCGwV9KeVBXxH17R/merLXaovqWco7ySQvoAODDBhQ==', 2);
 DECLARE @ID_USUARIO INT = SCOPE_IDENTITY();
 INSERT INTO CUENTA (ID_USUARIO, SALDO, ALIAS, CBU)
 VALUES (@ID_USUARIO, 10000.00, 'digitalars.juan.perez', 1234567890000001);
 GO
 
 -- Usuario 2
+-- Contraseña: clave123
 INSERT INTO USUARIO (NOMBRE, EMAIL, PASS, ID_ROL)
-VALUES ('Mar a G mez', 'maria.gomez@mail.com', 'clave123', 2);
+VALUES ('Mar a G mez', 'maria.gomez@mail.com', 'AQAAAAIAAYagAAAAEOVbyrLGHjDWRBbPdNX6PLweN1SdeFU2D2neUEcoC4dBzXVtd26Kqe6B6yStNl/jEg==', 2);
 DECLARE @ID_USUARIO INT = SCOPE_IDENTITY();
 INSERT INTO CUENTA (ID_USUARIO, SALDO, ALIAS, CBU)
 VALUES (@ID_USUARIO, 10000.00, 'digitalars.maria.gomez', 1234567890000002);
 GO
 
 -- Usuario 3
+-- Contraseña: clave123
 INSERT INTO USUARIO (NOMBRE, EMAIL, PASS, ID_ROL)
-VALUES ('Carlos L pez', 'carlos.lopez@mail.com', 'clave123', 2);
+VALUES ('Carlos L pez', 'carlos.lopez@mail.com', 'AQAAAAIAAYagAAAAEDUflfk7t9vxhO2mS0qbRG4O33KtfBDSuPU5cB31cr0JwwS3Xdzn73Ekdg1sjEBg8g==', 2);
 DECLARE @ID_USUARIO INT = SCOPE_IDENTITY();
 INSERT INTO CUENTA (ID_USUARIO, SALDO, ALIAS, CBU)
 VALUES (@ID_USUARIO, 10000.00, 'digitalars.carlos.lopez', 1234567890000003);
 GO
 
 -- Usuario 4
+-- Contraseña: clave123
 INSERT INTO USUARIO (NOMBRE, EMAIL, PASS, ID_ROL)
-VALUES ('Ana Mart nez', 'ana.martinez@mail.com', 'clave123', 2);
+VALUES ('Ana Mart nez', 'ana.martinez@mail.com', 'AQAAAAIAAYagAAAAECQoQcBFOSu1fSsBHyW8zY7TGesdluEJzivKNfKQgW8wj5gxbd3ugKHzN9ZmKUxHjg==', 2);
 DECLARE @ID_USUARIO INT = SCOPE_IDENTITY();
 INSERT INTO CUENTA (ID_USUARIO, SALDO, ALIAS, CBU)
 VALUES (@ID_USUARIO, 10000.00, 'digitalars.ana.martinez', 1234567890000004);
 GO
 
 -- Usuario 5
+-- Contraseña: clave123
 INSERT INTO USUARIO (NOMBRE, EMAIL, PASS, ID_ROL)
-VALUES ('Pedro Ram rez', 'pedro.ramirez@mail.com', 'clave123', 2);
+VALUES ('Pedro Ram rez', 'pedro.ramirez@mail.com', 'AQAAAAIAAYagAAAAEIvsRbt7fwaXZVvfloDuOgt2Jk2i7hwiNYFgCv9ZDwwXjn6LZQ5mx49H5HFpI1rkMg==', 2);
 DECLARE @ID_USUARIO INT = SCOPE_IDENTITY();
 INSERT INTO CUENTA (ID_USUARIO, SALDO, ALIAS, CBU)
 VALUES (@ID_USUARIO, 10000.00, 'digitalars.pedro.ramirez', 1234567890000005);
 GO
 
 -- Usuario 6
+-- Contraseña: clave123
 INSERT INTO USUARIO (NOMBRE, EMAIL, PASS, ID_ROL)
-VALUES ('Laura S nchez', 'laura.sanchez@mail.com', 'clave123', 2);
+VALUES ('Laura S nchez', 'laura.sanchez@mail.com', 'AQAAAAIAAYagAAAAEHqBeqxjppyqmZH+d7rJIAUQWddxZojj0mcX9+M/VCM2tDccabKsYal2LK66mltJZQ==', 2);
 DECLARE @ID_USUARIO INT = SCOPE_IDENTITY();
 INSERT INTO CUENTA (ID_USUARIO, SALDO, ALIAS, CBU)
 VALUES (@ID_USUARIO, 10000.00, 'digitalars.laura.sanchez', 1234567890000006);
 GO
 
 -- Usuario 7
+-- Contraseña: clave123
 INSERT INTO USUARIO (NOMBRE, EMAIL, PASS, ID_ROL)
-VALUES ('Diego Torres', 'diego.torres@mail.com', 'clave123', 2);
+VALUES ('Diego Torres', 'diego.torres@mail.com', 'AQAAAAIAAYagAAAAEBR8NpOzR/PkUaYDqyzTS+u8YiQ5COf1aOWsc6F442Fpyt/5tXQrUFyFWNE8NnMzkQ==', 2);
 DECLARE @ID_USUARIO INT = SCOPE_IDENTITY();
 INSERT INTO CUENTA (ID_USUARIO, SALDO, ALIAS, CBU)
 VALUES (@ID_USUARIO, 10000.00, 'digitalars.diego.torres', 1234567890000007);
 GO
 
 -- Usuario 8
+-- Contraseña: clave123
 INSERT INTO USUARIO (NOMBRE, EMAIL, PASS, ID_ROL)
-VALUES ('Camila D az', 'camila.diaz@mail.com', 'clave123', 2);
+VALUES ('Camila D az', 'camila.diaz@mail.com', 'AQAAAAIAAYagAAAAELWo4JODUoTtp4V4dEtsneovyTP9KgkWk2iM8JKx6ifYS2ZBdAZn/1MRQlkO7vCtQg==', 2);
 DECLARE @ID_USUARIO INT = SCOPE_IDENTITY();
 INSERT INTO CUENTA (ID_USUARIO, SALDO, ALIAS, CBU)
 VALUES (@ID_USUARIO, 10000.00, 'digitalars.camila.diaz', 1234567890000008);
 GO
 
 -- Usuario 9
+-- Contraseña: clave123
 INSERT INTO USUARIO (NOMBRE, EMAIL, PASS, ID_ROL)
-VALUES ('Luc a Romero', 'lucia.romero@mail.com', 'clave123', 2);
+VALUES ('Luc a Romero', 'lucia.romero@mail.com', 'AQAAAAIAAYagAAAAEAUUypLf6w33Kh8cw+1vdjnb1Q5tMsj1MDymiHESMozOx3+hBekj51CaFFhtIGjf5Q==', 2);
 DECLARE @ID_USUARIO INT = SCOPE_IDENTITY();
 INSERT INTO CUENTA (ID_USUARIO, SALDO, ALIAS, CBU)
 VALUES (@ID_USUARIO, 10000.00, 'digitalars.lucia.romero', 1234567890000009);
 GO
 
 -- Usuario 10
+-- Contraseña: clave123
 INSERT INTO USUARIO (NOMBRE, EMAIL, PASS, ID_ROL)
-VALUES ('Javier Herrera', 'javier.herrera@mail.com', 'clave123', 2);
+VALUES ('Javier Herrera', 'javier.herrera@mail.com', 'AQAAAAIAAYagAAAAEK8QEMdK8P8nGj372ALbPm0ay1pI/+u7/uosWl9ZjsTO/tkU7t5F0gDUE2MFW6mhmA==', 2);
 DECLARE @ID_USUARIO INT = SCOPE_IDENTITY();
 INSERT INTO CUENTA (ID_USUARIO, SALDO, ALIAS, CBU)
 VALUES (@ID_USUARIO, 10000.00, 'digitalars.javier.herrera', 1234567890000010);
 GO
 
 -- Usuario 11
+-- Contraseña: clave123
 INSERT INTO USUARIO (NOMBRE, EMAIL, PASS, ID_ROL)
-VALUES ('Valentina Rojas', 'valentina.rojas@mail.com', 'clave123', 2);
+VALUES ('Valentina Rojas', 'valentina.rojas@mail.com', 'AQAAAAIAAYagAAAAEA6Wmz1n2PxpJh7gz809nmajFO5NSCegU7mna1AuwByik3OAjLlf6nLiFr4j0TDIlg==', 2);
 DECLARE @ID_USUARIO INT = SCOPE_IDENTITY();
 INSERT INTO CUENTA (ID_USUARIO, SALDO, ALIAS, CBU)
 VALUES (@ID_USUARIO, 10000.00, 'digitalars.valentina.rojas', 1234567890000011);
 GO
 
 -- Usuario 12
+-- Contraseña: clave123
 INSERT INTO USUARIO (NOMBRE, EMAIL, PASS, ID_ROL)
-VALUES ('Mart n Castro', 'martin.castro@mail.com', 'clave123', 2);
+VALUES ('Mart n Castro', 'martin.castro@mail.com', 'AQAAAAIAAYagAAAAEFUE5fHHO3DR4TLNKK9Igs2YYih6WMd/uXNiaCzNnGBUIPNuOUrVQh5k9FtQjiOOhQ==', 2);
 DECLARE @ID_USUARIO INT = SCOPE_IDENTITY();
 INSERT INTO CUENTA (ID_USUARIO, SALDO, ALIAS, CBU)
 VALUES (@ID_USUARIO, 10000.00, 'digitalars.martin.castro', 1234567890000012);
 GO
 
 -- Usuario 13
+-- Contraseña: clave123
 INSERT INTO USUARIO (NOMBRE, EMAIL, PASS, ID_ROL)
-VALUES ('Sof a Morales', 'sofia.morales@mail.com', 'clave123', 2);
+VALUES ('Sof a Morales', 'sofia.morales@mail.com', 'AQAAAAIAAYagAAAAEA1f/Z6n7nefWC1Mlep25A1qILY0y+q6lqiBJerjTWpCuEuRQEd7gSHU+4sFn6cKlQ==', 2);
 DECLARE @ID_USUARIO INT = SCOPE_IDENTITY();
 INSERT INTO CUENTA (ID_USUARIO, SALDO, ALIAS, CBU)
 VALUES (@ID_USUARIO, 10000.00, 'digitalars.sofia.morales', 1234567890000013);
 GO
 
 -- Usuario 14
+-- Contraseña: clave123
 INSERT INTO USUARIO (NOMBRE, EMAIL, PASS, ID_ROL)
-VALUES ('Federico Aguirre', 'federico.aguirre@mail.com', 'clave123', 2);
+VALUES ('Federico Aguirre', 'federico.aguirre@mail.com', 'AQAAAAIAAYagAAAAEKc0evB4xaEHMIz+gjqxawPaArJPoFZJpfoNfF5gS3qy4D5YX+ZFL4soaVbtT759Rg==', 2);
 DECLARE @ID_USUARIO INT = SCOPE_IDENTITY();
 INSERT INTO CUENTA (ID_USUARIO, SALDO, ALIAS, CBU)
 VALUES (@ID_USUARIO, 10000.00, 'digitalars.federico.aguirre', 1234567890000014);
 GO
 
 -- Usuario 15
+-- Contraseña: clave123
 INSERT INTO USUARIO (NOMBRE, EMAIL, PASS, ID_ROL)
-VALUES ('Isabella Paredes', 'isabella.paredes@mail.com', 'clave123', 2);
+VALUES ('Isabella Paredes', 'isabella.paredes@mail.com', 'AQAAAAIAAYagAAAAECa5sPw0x/jFpuGT9919e4UqttgFSigGwGrefsdKhsk/WN61xztDI/mXDs71uWbD9w==', 2);
 DECLARE @ID_USUARIO INT = SCOPE_IDENTITY();
 INSERT INTO CUENTA (ID_USUARIO, SALDO, ALIAS, CBU)
 VALUES (@ID_USUARIO, 10000.00, 'digitalars.isabella.paredes', 1234567890000015);
 GO
 
 -- Usuario 16
+-- Contraseña: clave123
 INSERT INTO USUARIO (NOMBRE, EMAIL, PASS, ID_ROL)
-VALUES ('Tom s Ib  ez', 'tomas.ibanez@mail.com', 'clave123', 2);
+VALUES ('Tom s Ib  ez', 'tomas.ibanez@mail.com', 'AQAAAAIAAYagAAAAEFzm/67u/GhHxZq3sQN4K0QF6lDwxWr3I3mYLfSI4JWldLs85aVQXFCSLypOSQ+R/Q==', 2);
 DECLARE @ID_USUARIO INT = SCOPE_IDENTITY();
 INSERT INTO CUENTA (ID_USUARIO, SALDO, ALIAS, CBU)
 VALUES (@ID_USUARIO, 10000.00, 'digitalars.tomas.ibanez', 1234567890000016);
 GO
 
 -- Usuario 17
+-- Contraseña: clave123
 INSERT INTO USUARIO (NOMBRE, EMAIL, PASS, ID_ROL)
-VALUES ('Emilia Vera', 'emilia.vera@mail.com', 'clave123', 2);
+VALUES ('Emilia Vera', 'emilia.vera@mail.com', 'AQAAAAIAAYagAAAAEO+LUg1Y1n+sGDWRwXdbSG1AZOPDfuCbyZUEwf340D+NCoO7gmZfMHxRtM8X7A3tag==', 2);
 DECLARE @ID_USUARIO INT = SCOPE_IDENTITY();
 INSERT INTO CUENTA (ID_USUARIO, SALDO, ALIAS, CBU)
 VALUES (@ID_USUARIO, 10000.00, 'digitalars.emilia.vera', 1234567890000017);
 GO
 
 -- Usuario 18
+-- Contraseña: clave123
 INSERT INTO USUARIO (NOMBRE, EMAIL, PASS, ID_ROL)
-VALUES ('Mat as Salas', 'matias.salas@mail.com', 'clave123', 2);
+VALUES ('Mat as Salas', 'matias.salas@mail.com', 'AQAAAAIAAYagAAAAEBbSQqJmu8Lrj8i46eDg7j5lly5ioelpYEfKSsnRWx0KzcZ7zqYjs+i8ehuvP3IEHQ==', 2);
 DECLARE @ID_USUARIO INT = SCOPE_IDENTITY();
 INSERT INTO CUENTA (ID_USUARIO, SALDO, ALIAS, CBU)
 VALUES (@ID_USUARIO, 10000.00, 'digitalars.matias.salas', 1234567890000018);
 GO
 
 -- Usuario 19
+-- Contraseña: clave123
 INSERT INTO USUARIO (NOMBRE, EMAIL, PASS, ID_ROL)
-VALUES ('Agustina Godoy', 'agustina.godoy@mail.com', 'clave123', 2);
+VALUES ('Agustina Godoy', 'agustina.godoy@mail.com', 'AQAAAAIAAYagAAAAEOD0bOOaUP4FSEB2Jx/mqS42N3PcFwRkTJduyCQ7qjqNk/YtYvtQTH0/P1Yq/O85xg==', 2);
 DECLARE @ID_USUARIO INT = SCOPE_IDENTITY();
 INSERT INTO CUENTA (ID_USUARIO, SALDO, ALIAS, CBU)
 VALUES (@ID_USUARIO, 10000.00, 'digitalars.agustina.godoy', 1234567890000019);
 GO
 
 -- Usuario 20
+-- Contraseña: clave123
 INSERT INTO USUARIO (NOMBRE, EMAIL, PASS, ID_ROL)
-VALUES ('Nicol s Silva', 'nicolas.silva@mail.com', 'clave123', 2);
+VALUES ('Nicol s Silva', 'nicolas.silva@mail.com', 'AQAAAAIAAYagAAAAECSl2E/V+gWIuWgDTu5FQmLZ7fkNGSsag0fTSOcBYbqcyvej2OONitZRNbFahngpmg==', 2);
 DECLARE @ID_USUARIO INT = SCOPE_IDENTITY();
 INSERT INTO CUENTA (ID_USUARIO, SALDO, ALIAS, CBU)
 VALUES (@ID_USUARIO, 10000.00, 'digitalars.nicolas.silva', 1234567890000020);
 GO
 
 -- Usuario 21
+-- Contraseña: clave123
 INSERT INTO USUARIO (NOMBRE, EMAIL, PASS, ID_ROL)
-VALUES ('Florencia Navarro', 'florencia.navarro@mail.com', 'clave123', 2);
+VALUES ('Florencia Navarro', 'florencia.navarro@mail.com', 'AQAAAAIAAYagAAAAEAiH86SZUh8377oHlZjrYRGqjnkVUn8Dv5sMGY0T0S1B9QrdIzhom6UkWG5796nmXQ==', 2);
 DECLARE @ID_USUARIO INT = SCOPE_IDENTITY();
 INSERT INTO CUENTA (ID_USUARIO, SALDO, ALIAS, CBU)
 VALUES (@ID_USUARIO, 10000.00, 'digitalars.florencia.navarro', 1234567890000021);
 GO
 
 -- Usuario 22
+-- Contraseña: clave123
 INSERT INTO USUARIO (NOMBRE, EMAIL, PASS, ID_ROL)
-VALUES ('Sebasti n Correa', 'sebastian.correa@mail.com', 'clave123', 2);
+VALUES ('Sebasti n Correa', 'sebastian.correa@mail.com', 'AQAAAAIAAYagAAAAEI+YwRwqo+jzaINvxtGVi4D3k98F8SHEHWLT5Y13yC6WeIl9t4OI1S6xCpPQUiwwBQ==', 2);
 DECLARE @ID_USUARIO INT = SCOPE_IDENTITY();
 INSERT INTO CUENTA (ID_USUARIO, SALDO, ALIAS, CBU)
 VALUES (@ID_USUARIO, 10000.00, 'digitalars.sebastian.correa', 1234567890000022);
 GO
 
 -- Usuario 23
+-- Contraseña: clave123
 INSERT INTO USUARIO (NOMBRE, EMAIL, PASS, ID_ROL)
-VALUES ('Julieta M ndez', 'julieta.mendez@mail.com', 'clave123', 2);
+VALUES ('Julieta M ndez', 'julieta.mendez@mail.com', 'AQAAAAIAAYagAAAAEKANGvWij4Zr4c3esvv0oEwvlhZYI+3IzXwb9oueCGbTt7llPwo+ZDo84O2zRc0mIg==', 2);
 DECLARE @ID_USUARIO INT = SCOPE_IDENTITY();
 INSERT INTO CUENTA (ID_USUARIO, SALDO, ALIAS, CBU)
 VALUES (@ID_USUARIO, 10000.00, 'digitalars.julieta.mendez', 1234567890000023);
 GO
 
 -- Usuario 24
+-- Contraseña: clave123
 INSERT INTO USUARIO (NOMBRE, EMAIL, PASS, ID_ROL)
-VALUES ('Gonzalo Far as', 'gonzalo.farias@mail.com', 'clave123', 2);
+VALUES ('Gonzalo Far as', 'gonzalo.farias@mail.com', 'AQAAAAIAAYagAAAAEAf8rBH//6Ei7JbcZH3WUWzpthHeXJZeCi8/za7+BKM+U6WMSi+dWRxK5dwfrSGiKQ==', 2);
 DECLARE @ID_USUARIO INT = SCOPE_IDENTITY();
 INSERT INTO CUENTA (ID_USUARIO, SALDO, ALIAS, CBU)
 VALUES (@ID_USUARIO, 10000.00, 'digitalars.gonzalo.farias', 1234567890000024);
 GO
 
 -- Usuario 25
+-- Contraseña: clave123
 INSERT INTO USUARIO (NOMBRE, EMAIL, PASS, ID_ROL)
-VALUES ('Milagros Quiroga', 'milagros.quiroga@mail.com', 'clave123', 2);
+VALUES ('Milagros Quiroga', 'milagros.quiroga@mail.com', 'AQAAAAIAAYagAAAAEEa4Y5ndPPXf7OLBoJw33fpRAzcv5not0LN2sdk48Uw2FnrTVLbhull85VHRHw8ReA==', 2);
 DECLARE @ID_USUARIO INT = SCOPE_IDENTITY();
 INSERT INTO CUENTA (ID_USUARIO, SALDO, ALIAS, CBU)
 VALUES (@ID_USUARIO, 10000.00, 'digitalars.milagros.quiroga', 1234567890000025);
 GO
 
 -- Usuario 26
+-- Contraseña: clave123
 INSERT INTO USUARIO (NOMBRE, EMAIL, PASS, ID_ROL)
-VALUES ('Ramiro Pe a', 'ramiro.pena@mail.com', 'clave123', 2);
+VALUES ('Ramiro Pe a', 'ramiro.pena@mail.com', 'AQAAAAIAAYagAAAAEFwMcKWBZN3gy2I4vWohmNiYqc0BmHHeQW+JkyLMn+NmcKYEbBVM1Ss7R8Yi/tgSEg==', 2);
 DECLARE @ID_USUARIO INT = SCOPE_IDENTITY();
 INSERT INTO CUENTA (ID_USUARIO, SALDO, ALIAS, CBU)
 VALUES (@ID_USUARIO, 10000.00, 'digitalars.ramiro.pena', 1234567890000026);
 GO
 
 -- Usuario 27
+-- Contraseña: clave123
 INSERT INTO USUARIO (NOMBRE, EMAIL, PASS, ID_ROL)
-VALUES ('Martina Ruiz', 'martina.ruiz@mail.com', 'clave123', 2);
+VALUES ('Martina Ruiz', 'martina.ruiz@mail.com', 'AQAAAAIAAYagAAAAEAwlJM7hnvG0GKZwyusxfCaM56IL4tBSlQE97gNr9Ge6JaZemJoFdEBu9O7QiPRZrA==', 2);
 DECLARE @ID_USUARIO INT = SCOPE_IDENTITY();
 INSERT INTO CUENTA (ID_USUARIO, SALDO, ALIAS, CBU)
 VALUES (@ID_USUARIO, 10000.00, 'digitalars.martina.ruiz', 1234567890000027);
 GO
 
 -- Usuario 28
+-- Contraseña: clave123
 INSERT INTO USUARIO (NOMBRE, EMAIL, PASS, ID_ROL)
-VALUES ('Leandro Molina', 'leandro.molina@mail.com', 'clave123', 2);
+VALUES ('Leandro Molina', 'leandro.molina@mail.com', 'AQAAAAIAAYagAAAAELCr6sr6YnUHTEpQW7TUikZcS2nyo4uybQWNpldiLgvwdEYp1a7daxzHLHPOTlwGCg==', 2);
 DECLARE @ID_USUARIO INT = SCOPE_IDENTITY();
 INSERT INTO CUENTA (ID_USUARIO, SALDO, ALIAS, CBU)
 VALUES (@ID_USUARIO, 10000.00, 'digitalars.leandro.molina', 1234567890000028);
 GO
 
 -- Usuario 29
+-- Contraseña: clave123
 INSERT INTO USUARIO (NOMBRE, EMAIL, PASS, ID_ROL)
-VALUES ('Bianca Ayala', 'bianca.ayala@mail.com', 'clave123', 2);
+VALUES ('Bianca Ayala', 'bianca.ayala@mail.com', 'AQAAAAIAAYagAAAAECkqfZ2pMq++0OEzBcdpG3n+8uPYqW+khHxmncVTI9UIadGEhJVJbzqFJxHZUuKtEQ==', 2);
 DECLARE @ID_USUARIO INT = SCOPE_IDENTITY();
 INSERT INTO CUENTA (ID_USUARIO, SALDO, ALIAS, CBU)
 VALUES (@ID_USUARIO, 10000.00, 'digitalars.bianca.ayala', 1234567890000029);
 GO
 
 -- Usuario 30
+-- Contraseña: clave123
 INSERT INTO USUARIO (NOMBRE, EMAIL, PASS, ID_ROL)
-VALUES ('Facundo Del R o', 'facundo.delrio@mail.com', 'clave123', 2);
+VALUES ('Facundo Del R o', 'facundo.delrio@mail.com', 'AQAAAAIAAYagAAAAEIwM1ewRENjzXy5QAvCRgmjD02IAmH80NdXC8NmJ5p/u8pboR9Y92BIkxPKX6Vue2w==', 2);
 DECLARE @ID_USUARIO INT = SCOPE_IDENTITY();
 INSERT INTO CUENTA (ID_USUARIO, SALDO, ALIAS, CBU)
 VALUES (@ID_USUARIO, 10000.00, 'digitalars.facundo.delrio', 1234567890000030);


### PR DESCRIPTION
Se arregla un problema en el controlador `AuthController` en el endpoint "datos-usuario" en donde no se podía obtener el claim "Sub" usando el enum `JwtRegisteredClaimNames`.
En su lugar se usa el enum `ClaimTypes` para definir y obtener los claims del token.

Ademas, se actualiza el script sql para que los insert de los usuarios tengan las contraseñas ya hasheadas y asi no ocurra un error al intentar verificar la contraseña al hacer login.